### PR TITLE
Fix budget validation message

### DIFF
--- a/uis_accounts_customization/uis_accounts_customization/doctype/uis___budget/uis___budget.py
+++ b/uis_accounts_customization/uis_accounts_customization/doctype/uis___budget/uis___budget.py
@@ -8,8 +8,8 @@ from frappe.model.document import Document
 class UISBudget(Document):
 	def validate(self):
 
-		if not self.accounts and not self.fixed_assest:
-			frappe.throw("UIS - Budget need to be create aganist Account or Fixed Asset")
+                if not self.accounts and not self.fixed_assest:
+                        frappe.throw("UIS - Budget needs to be created against Account or Fixed Asset")
 
 		doc_filter = {
 			"branch" : self.branch,


### PR DESCRIPTION
## Summary
- correct grammar in UISBudget validation error message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_685d854dfcfc8322a0641a10a060f1a8