### PR TITLE
Add module docstrings

### DIFF
--- a/uis_accounts_customization/customization_script/budget.py
+++ b/uis_accounts_customization/customization_script/budget.py
@@ -1,3 +1,25 @@
+"""Custom budget validation utilities for UIS.
+
+The functions in this module extend ERPNext's standard budget checks. They
+retrieve budget data from custom "UIS - Budget" documents and compare expenses
+against allocated amounts for various documents such as purchase invoices or
+general ledger entries. The helpers also provide APIs to compute the remaining
+budget for a given account or item and enqueue jobs for budget checking.
+
+Key functions
+-------------
+``verify_validate_expense_against_budget``
+    Iterates over GL entries produced by a document and triggers validation.
+
+``validate_expense_against_budget``
+    Core function that fetches matching budget records and verifies that the
+    transaction does not exceed them.
+
+``get_remaining_budget``
+    Public API used to fetch the remaining budget amount for a particular
+    expense account.
+"""
+
 import frappe
 
 from erpnext.accounts.utils import get_fiscal_year

--- a/uis_accounts_customization/customization_script/handler.py
+++ b/uis_accounts_customization/customization_script/handler.py
@@ -1,3 +1,23 @@
+"""Utilities used for field validation during document save events.
+
+This module hooks into various DocType events to ensure that mandatory
+company specific fields such as ``branch``, ``cost_center``, ``department`` and
+``project`` are present on the document.  It also checks child table rows for
+the same mandatory data and verifies that the values exist for the given
+company.  If any issues are found a consolidated error message is thrown using
+``frappe.throw``.
+
+Key functions
+-------------
+``validate``
+    Entry point executed on the ``validate`` event of a document.  It inspects
+    all fields and delegates the mandatory checks to ``get_meta_info``.
+
+``get_meta_info``
+    Performs the actual validation and collects error messages for missing or
+    invalid references.
+"""
+
 import frappe
 
 def validate(doc, method):

--- a/uis_accounts_customization/uis_accounts_customization/api/utils.py
+++ b/uis_accounts_customization/uis_accounts_customization/api/utils.py
@@ -1,3 +1,21 @@
+"""Helper APIs for custom budget allocation and master data creation.
+
+This module exposes whitelisted functions that are callable from the client
+side. They provide utility features for budget allocation checks on Purchase
+Invoices and other transactions as well as background jobs that create State
+and City masters by consuming data from an external API.
+
+Key functions
+-------------
+``get_allocated_amount``
+    Determines the remaining budget for a given document row, supporting both
+    asset and expense based budgeting.
+
+``create_state_city``
+    Enqueues long running background tasks that populate the ``State`` and
+    ``City`` doctypes using the `countriesnow.space` API.
+"""
+
 import frappe
 from frappe.utils import getdate
 import requests


### PR DESCRIPTION
## Summary
- document handler validation utilities
- document custom budget utilities
- document API helpers for budget allocation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_685d854ffe7483229f93a577ec0b12a4