### PR TITLE
Update README and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 Accounts Description
 
-#### License
+### Setup
 
-mit
+1. Install [Frappe Framework](https://frappeframework.com/docs/user/en/installation).
+2. Create a new bench instance and install the app:
+
+```bash
+bench init my-bench
+cd my-bench
+bench get-app /path/to/this/repo
+bench new-site site1.local
+bench --site site1.local install-app uis_accounts_customization
+bench start
+```
+
+### License
+
+This project is licensed under the [MIT License](license.txt).

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2025 Actinoids-IO
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- add setup instructions and license section
- update placeholder details in license.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_685d854b81a883228ca9b490bf9b27e5