### PR TITLE
Fix Sales Order path in hooks

### DIFF
--- a/uis_accounts_customization/hooks.py
+++ b/uis_accounts_customization/hooks.py
@@ -138,7 +138,7 @@ doctype_js = {
 # Override standard doctype classes
 
 override_doctype_class = {
-	"Sales Order": "uis_accounts_customization.uis_accounts_customization.customization_script.sales_order.OverrideSalesOrder"
+    "Sales Order": "uis_accounts_customization.customization_script.sales_order.OverrideSalesOrder"
 }
 
 # Document Events


### PR DESCRIPTION
## Summary
- correct location for Sales Order override module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6862da66daf8832290bc432052d1193b